### PR TITLE
DNS caching fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,20 @@ os:
 #  - osx
 
 env:
-  - V=0.21.0
+  global:
+    - V=0.21.0
+  matrix:
+    - TEST=bazel
+    - TEST=inMemoryBootstrap
+    - TEST=inMemoryRestart
+    - TEST=remoteRestart
+    - TEST=remoteLayerCalculation
+
+
+addons:
+  apt:
+    packages:
+      - jq
 
 before_install:
   - |
@@ -29,15 +42,24 @@ before_install:
 
 script:
   - |
-    bazel \
-      --output_base=$HOME/.cache/bazel \
-      --host_jvm_args=-Xmx500m \
-      --host_jvm_args=-Xms500m \
-      test \
-      --config=ci \
-      --experimental_repository_cache="$HOME/.bazel_repository_cache" \
-      --local_resources=400,1,1.0 \
-      //...
+    if [[ "${TEST}" == "bazel" ]]; then
+      bazel \
+          --output_base=$HOME/.cache/bazel \
+          --host_jvm_args=-Xmx500m \
+          --host_jvm_args=-Xms500m \
+          test \
+          --config=ci \
+          --experimental_repository_cache="$HOME/.bazel_repository_cache" \
+          --local_resources=400,1,1.0 \
+          //...
+    fi
+  # run HOW TO steps
+  - |
+    if [[ "${TEST}" != "bazel" ]]; then
+      /bin/sh CI/setupTests.sh;
+      /bin/sh CI/${TEST}.sh;
+      sudo /bin/sh CI/cleanUp.sh;
+    fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_install:
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
       OS=darwin
     else
-      sysctl kernel.unprivileged_userns_clone=1
       OS=linux
     fi
     URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"

--- a/CI/checkLogs.sh
+++ b/CI/checkLogs.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+scriptdir=$(dirname "$(readlink -f "$0")")
+
+echo "checking containers are running"
+if ! [ `docker ps | grep iri | cut -f1 -d\ ` ]; then
+    echo "IRI exited, see logs"
+    exit 255
+fi
+
+if ! [ `docker ps | grep coordinator | cut -f1 -d\ ` ]; then
+    echo "Compass exited, see logs"
+    exit 255
+fi
+
+echo "scanning logs for errors"
+if docker logs $(docker ps | grep iri | cut -f1 -d\ ) | grep -i 'error'; then
+    echo "IRI threw errors, see logs"
+    exit 255
+fi
+if docker logs $(docker ps | grep coordinator | cut -f1 -d\ ) | grep -i 'error'; then
+    echo "Compass threw errors, see logs"
+    exit 255
+fi

--- a/CI/cleanUp.sh
+++ b/CI/cleanUp.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+echo "cleaning up"
+COO_CONTAINER=`docker ps | grep coordinator | cut -f1 -d\ `
+if [ "$COO_CONTAINER" ]; then
+    docker kill $COO_CONTAINER
+fi
+
+IRI_CONTAINER=`docker ps | grep iri | cut -f1 -d\ `
+if [ "$IRI_CONTAINER" ]; then
+    docker kill $IRI_CONTAINER
+fi
+
+SIG_SOURCE_SERVER_CONTAINER=`docker ps | grep signature_source_server | cut -f1 -d\ `
+if [ "$SIG_SOURCE_SERVER_CONTAINER" ]; then
+    docker kill $SIG_SOURCE_SERVER_CONTAINER
+fi
+
+rm -rf docs/private_tangle/data
+rm -rf docs/private_tangle/db
+

--- a/CI/inMemoryBootstrap.sh
+++ b/CI/inMemoryBootstrap.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+scriptdir=$(dirname "$(readlink -f "$0")")
+
+if ! /bin/sh ${scriptdir}/startIRI.sh; then
+    exit 255
+fi
+
+
+
+cd docs/private_tangle
+
+echo "starting Compass bootstrap"
+./03_run_coordinator.sh -bootstrap -broadcast &
+#let compass run for a while
+sleep 30
+
+if ! /bin/sh ${scriptdir}/checkLogs.sh; then
+    exit 255
+fi
+
+cd ../..

--- a/CI/inMemoryRestart.sh
+++ b/CI/inMemoryRestart.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+scriptdir=$(dirname "$(readlink -f "$0")")
+
+if ! /bin/sh ${scriptdir}/startIRI.sh; then
+    exit 255
+fi
+
+cd docs/private_tangle
+
+echo "starting Compass bootstrap"
+./03_run_coordinator.sh -bootstrap -broadcast &
+sleep 20
+
+echo "restarting Compass"
+docker kill $(docker ps | grep coordinator | cut -f1 -d\ )
+while [ `docker ps | grep coordinator | cut -f1 -d\ ` ]; do
+sleep 1;
+done
+sleep 2
+
+./03_run_coordinator.sh -broadcast &
+sleep 20
+
+if ! /bin/sh ${scriptdir}/checkLogs.sh; then
+    exit 255
+fi
+
+cd ../..

--- a/CI/remoteLayerCalculation.sh
+++ b/CI/remoteLayerCalculation.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+cd docs/private_tangle
+
+ROOT_TREE_LOCAL=`cat data/layers/layer.0.csv`
+echo "starting Signing server"
+./11_run_signature_source_server.sh &
+sleep 10
+
+echo "starting remote layer calculation"
+./21_calculate_layers_remote.sh
+
+echo "compare results"
+ROOT_TREE_REMOTE=`cat data/layers/layer.0.csv`
+if [ ${ROOT_TREE_REMOTE} = ${ROOT_TREE_LOCAL} ]; then
+  echo "same";
+else
+  >&2 echo "different: ${ROOT_TREE_REMOTE} != ${ROOT_TREE_LOCAL}"
+  exit 255
+fi
+
+cd ../..

--- a/CI/remoteRestart.sh
+++ b/CI/remoteRestart.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+scriptdir=$(dirname "$(readlink -f "$0")")
+
+if ! /bin/sh ${scriptdir}/startIRI.sh; then
+    exit 255
+fi
+
+cd docs/private_tangle
+
+echo "starting Signing server"
+./11_run_signature_source_server.sh &
+sleep 10
+
+echo "starting Compass bootstrap"
+./12_run_coordinator_remote.sh -bootstrap -broadcast &
+sleep 20
+
+echo "restarting Compass"
+docker kill $(docker ps | grep coordinator | cut -f1 -d\ )
+while [ `docker ps | grep coordinator | cut -f1 -d\ ` ]; do
+sleep 1;
+done
+sleep 2
+
+./12_run_coordinator_remote.sh -broadcast &
+sleep 20
+
+if ! /bin/sh ${scriptdir}/checkLogs.sh; then
+    exit 255
+fi
+
+cd ../..

--- a/CI/setupTests.sh
+++ b/CI/setupTests.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+scriptdir=$(dirname "$(readlink -f "$0")")
+
+#prep environment
+echo "building docker images"
+bazel run //docker:coordinator
+bazel run //docker:layers_calculator
+bazel run //docker:signature_source_server
+
+echo "setting up configs"
+cd docs/private_tangle
+cat config.example.json| jq '.tick = 5000' > config.json
+cp snapshot.example.txt snapshot.txt
+
+echo "calculating merkle tree"
+./01_calculate_layers.sh
+
+cd ${scriptdir}

--- a/CI/startIRI.sh
+++ b/CI/startIRI.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+cd docs/private_tangle
+
+echo "starting IRI"
+./02_run_iri.sh &
+until [ `docker ps | grep iri | cut -f1 -d\ ` ]; do
+sleep 1;
+done
+
+echo "waiting for IRI to start"
+while ! curl http://localhost:14265 -X POST -H 'Content-Type: application/json' -H 'X-IOTA-API-Version: 1' -d '{"command": "getNodeInfo"}'; do
+    echo "API not ready"
+    sleep 1;
+    if ! [ `docker ps | grep iri | cut -f1 -d\ ` ]; then
+        echo "IRI failed to initialize"
+        exit 255
+    fi
+done
+echo ""
+echo "IRI initialized"

--- a/Security.MD
+++ b/Security.MD
@@ -1,0 +1,23 @@
+<h2>Responsible disclosure policy</h2>
+
+At the IOTA Foundation, we consider the security of our systems a top priority. But no matter how much effort we put into system security, there can still be vulnerabilities present. If you've discovered a vulnerability, please follow the guidelines below to report it to our security team:
+<ul>
+	<li>E-mail your findings to secops@iota.org. If the report contains highly sensitive information, please consider encrypting your findings using our contact@iota.org (466385BD0B40D9550F93C04746A440CCE5664A64) PGP key.</li>
+</ul>
+Please follow these rules when testing/reporting vulnerabilities:
+<ul>
+	<li>Do not take advantage of the vulnerability you have discovered, for example by downloading more data than is necessary to demonstrate the vulnerability.</li>
+	<li>Do not read, modify or delete data that isn't you own.</li>
+	<li>We ask that you do not to disclosure the problem to third parties until it has been resolved.</li>
+	<li>The scope of the program is limited to technical vulnerabilities in IOTA Foundations's web applications and open source software packages distributed through GitHub, please do not try to test physical security or attempt phishing attacks against our employees, and so on.</li>
+	<li>Out of concern for the availability of our services to all users, please do not attempt to carry out DoS attacks, leverage black hat SEO techniques, spam people, and do other similarly questionable things. We also discourage the use of any vulnerability testing tools that automatically generate significant volumes of traffic.</li>
+</ul>
+What we promise:
+<ul>
+	<li>We will respond to your report within 3 business days with our evaluation of the report and an expected resolution date.</li>
+	<li>If you have followed the instructions above, we will not take any legal action against you in regard to the report.</li>
+	<li>We will keep you informed during all stages of resolving the problem.</li>
+	<li>To show our appreciation for your effort and cooperation during the report, we will list your name and a link to a personal website/social network profile on the page below so that the public can know you've helped keep the IOTA Foundation secure.</li>
+</ul>
+We sincerely appreciate the efforts of security researchers in keeping our community safe.
+

--- a/compass/BUILD
+++ b/compass/BUILD
@@ -10,6 +10,7 @@ COORDINATOR_RUNTIME_DEPS = [
 java_binary(
     name = "layers_calculator",
     srcs = ["LayersCalculator.java"],
+    classpath_resources = ["simplelogger.properties"],
     main_class = "org.iota.compass.LayersCalculator",
     visibility = ["//visibility:public"],
     runtime_deps = COORDINATOR_RUNTIME_DEPS,
@@ -28,6 +29,7 @@ java_binary(
 java_binary(
     name = "shadowing_coordinator",
     srcs = ["ShadowingCoordinator.java"],
+    classpath_resources = ["simplelogger.properties"],
     main_class = "org.iota.compass.ShadowingCoordinator",
     visibility = ["//visibility:public"],
     runtime_deps = COORDINATOR_RUNTIME_DEPS,
@@ -47,6 +49,7 @@ java_binary(
 java_binary(
     name = "coordinator",
     srcs = ["Coordinator.java"],
+    classpath_resources = ["simplelogger.properties"],
     main_class = "org.iota.compass.Coordinator",
     visibility = ["//visibility:public"],
     runtime_deps = COORDINATOR_RUNTIME_DEPS,

--- a/compass/BUILD
+++ b/compass/BUILD
@@ -55,6 +55,7 @@ java_binary(
     runtime_deps = COORDINATOR_RUNTIME_DEPS,
     deps = [
         "//compass/conf",
+        "//compass/exceptions",
         "//compass/milestone",
         "//compass/sign:common",
         "//compass/sign:helper",

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.URI;
 import java.net.URL;
+import java.security.Security;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -113,6 +114,11 @@ public class Coordinator {
   }
 
   public static void main(String[] args) throws Exception {
+
+    // Limit DNS caching for resolved and failed records to 5 seconds
+    Security.setProperty("networkaddress.cache.ttl" , "5");
+    Security.setProperty("networkaddress.cache.negative.ttl" , "5");
+
     CoordinatorConfiguration config = new CoordinatorConfiguration();
     CoordinatorState state;
 

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -26,14 +26,10 @@
 package org.iota.compass;
 
 import com.beust.jcommander.JCommander;
-import jota.IotaAPI;
-import jota.dto.response.CheckConsistencyResponse;
-import jota.dto.response.GetNodeInfoResponse;
-import jota.dto.response.GetTransactionsToApproveResponse;
-import jota.error.ArgumentException;
-import jota.model.Transaction;
+
 import org.iota.compass.conf.CoordinatorConfiguration;
 import org.iota.compass.conf.CoordinatorState;
+import org.iota.compass.exceptions.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +39,13 @@ import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import jota.IotaAPI;
+import jota.dto.response.CheckConsistencyResponse;
+import jota.dto.response.GetNodeInfoResponse;
+import jota.dto.response.GetTransactionsToApproveResponse;
+import jota.error.ArgumentException;
+import jota.model.Transaction;
 
 public class Coordinator {
   private static final Logger log = LoggerFactory.getLogger(Coordinator.class);
@@ -226,6 +229,8 @@ public class Coordinator {
     int milestonePropagationRetries = 0;
 
     while (true) {
+      //assume that we will be calling gtta
+      boolean isReferencingLastMilestone = false;
       String trunk, branch;
       GetNodeInfoResponse nodeInfoResponse = getNodeInfoWithRetries();
 
@@ -258,14 +263,24 @@ public class Coordinator {
         //normal flow
         else {
           // GetTransactionsToApprove will return tips referencing latest milestone.
-          GetTransactionsToApproveResponse txToApprove = getGetTransactionsToApproveResponseWithRetries();
-          trunk = txToApprove.getTrunkTransaction();
-          if (trunk == null || trunk.isEmpty()) {
-            throw new RuntimeException("GTTA failed to return trunk");
-          }
-          branch = txToApprove.getBranchTransaction();
-          if (branch == null || branch.isEmpty()) {
-            throw new RuntimeException("GTTA failed to return branch");
+          GetTransactionsToApproveResponse txToApprove = null;
+          try {
+            txToApprove = getGetTransactionsToApproveResponseWithRetries();
+
+            trunk = txToApprove.getTrunkTransaction();
+            if (trunk == null || trunk.isEmpty()) {
+              throw new RuntimeException("GTTA failed to return trunk");
+            }
+            branch = txToApprove.getBranchTransaction();
+            if (branch == null || branch.isEmpty()) {
+              throw new RuntimeException("GTTA failed to return branch");
+            }
+          } catch (TimeoutException e) {
+            log.warn("Due to timeout we will now reference last milestone");
+            trunk = state.latestMilestoneHash;
+            branch = state.latestMilestoneHash;
+            //gtta was not used so we set this flag to true
+            isReferencingLastMilestone = true;
           }
         }
 
@@ -308,7 +323,7 @@ public class Coordinator {
       state.latestMilestoneIndex++;
 
       createAndBroadcastMilestone(trunk, branch);
-      updateDepth(bootstrapStage);
+      updateDepth(bootstrapStage, isReferencingLastMilestone);
       state.latestMilestoneTime = System.currentTimeMillis();
 
       // Everything went fine, now we store
@@ -335,7 +350,12 @@ public class Coordinator {
     }
   }
 
-  private void updateDepth(int bootstrap) {
+  private void updateDepth(int bootstrap, boolean minimizeDepth) {
+    if (minimizeDepth) {
+      depth = config.minDepth;
+      return;
+    }
+
     int nextDepth;
     if (bootstrap >= 3) {
       nextDepth = getNextDepth(depth, state.latestMilestoneTime);
@@ -405,15 +425,25 @@ public class Coordinator {
     return response;
   }
 
-  private GetTransactionsToApproveResponse getGetTransactionsToApproveResponseWithRetries() throws InterruptedException {
+  private GetTransactionsToApproveResponse getGetTransactionsToApproveResponseWithRetries() throws
+          TimeoutException, InterruptedException {
     GetTransactionsToApproveResponse response = null;
     for(int i = 0; i < config.APIRetries; i++) {
       try {
         response = api.getTransactionsToApprove(depth, state.latestMilestoneHash);
         break;
-      } catch (IllegalStateException | ArgumentException | IllegalAccessError e) {
+      } catch (IllegalStateException | IllegalAccessError e) {
         log.error("API call failed: ", e);
         Thread.sleep(config.APIRetryInterval);
+      }
+      catch  (ArgumentException e) {
+        log.error("There was a problem processing Get Transactions To Approve: ", e);
+        if (e.getMessage().contains("exceeded timeout")) {
+          throw new TimeoutException("Get Transactions To Approve call timed out", e);
+        }
+        else {
+          Thread.sleep(config.APIRetryInterval);
+        }
       }
     }
     if (response == null) {

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -354,8 +354,7 @@ public class Coordinator {
           }
           return response.getState();
         } catch (InterruptedException e) {
-          e.printStackTrace();
-          return false;
+          throw new RuntimeException("Validation of transactions to approve failed", e);
         }
       });
     }

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -253,7 +253,13 @@ public class Coordinator {
         // GetTransactionsToApprove will return tips referencing latest milestone.
         GetTransactionsToApproveResponse txToApprove = getGetTransactionsToApproveResponseWithRetries();
         trunk = txToApprove.getTrunkTransaction();
+        if (trunk == null || trunk.isEmpty()) {
+          throw new RuntimeException("GTTA failed to return trunk");
+        }
         branch = txToApprove.getBranchTransaction();
+        if (branch == null || branch.isEmpty()) {
+          throw new RuntimeException("GTTA failed to return branch");
+        }
 
         if (!validateTransactionsToApprove(trunk, branch)) {
           throw new RuntimeException("Trunk & branch were not consistent!!! T: " + trunk + " B: " + branch);

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -55,7 +55,7 @@ public class Coordinator {
   private long milestoneTick;
   private int depth;
 
-  public Coordinator(CoordinatorConfiguration config, CoordinatorState state, SignatureSource signatureSource) throws IOException {
+  private Coordinator(CoordinatorConfiguration config, CoordinatorState state, SignatureSource signatureSource) throws IOException {
     this.config = config;
     this.state = state;
     URL node = new URL(config.host);
@@ -131,7 +131,7 @@ public class Coordinator {
    * @param lastTimestamp when the current round started
    * @return depth for the next round
    */
-  protected int getNextDepth(int currentDepth, long lastTimestamp) {
+  private int getNextDepth(int currentDepth, long lastTimestamp) {
     long now = System.currentTimeMillis();
     int nextDepth;
 
@@ -160,7 +160,7 @@ public class Coordinator {
    * @param nodeInfo response from node API call
    * @return true if node is solid
    */
-  protected boolean nodeIsSolid(GetNodeInfoResponse nodeInfo) {
+  private boolean nodeIsSolid(GetNodeInfoResponse nodeInfo) {
     if (nodeInfo.getLatestSolidSubtangleMilestoneIndex() != nodeInfo.getLatestMilestoneIndex())
       return false;
 
@@ -233,7 +233,6 @@ public class Coordinator {
 
     while (true) {
       String trunk, branch;
-      int nextDepth;
       GetNodeInfoResponse nodeInfoResponse = api.getNodeInfo();
 
       if (bootstrap == 2 && !nodeIsSolid(nodeInfoResponse)) {
@@ -256,24 +255,17 @@ public class Coordinator {
         bootstrap++;
       } else {
         if (!nodeIsSolid(nodeInfoResponse)) {
-          // Bail if we attempted to broadcast the latest Milestone too many times
-          if (milestonePropagationRetries > config.propagationRetriesThreshold) {
-            String msg =
-                    "Latest milestone " + state.latestMilestoneHash + " #" +
-                    state.latestMilestoneIndex + " is failing to propagate!!!";
-
-            log.error(msg);
-            throw new RuntimeException(msg);
+          if (attemptToRepropagateLatestMilestone(milestonePropagationRetries,
+                  nodeInfoResponse.getLatestSolidSubtangleMilestoneIndex())) {
+            milestonePropagationRetries++;
+            // We wait a third of the milestone tick
+            Thread.sleep(milestoneTick / 3);
+            continue;
           }
-          log.warn("getNodeInfo returned latestSolidSubtangleMilestoneIndex #{}, " +
-                  "it should be #{}. Rebroadcasting latest milestone.",
-                  nodeInfoResponse.getLatestSolidSubtangleMilestoneIndex(), state.latestMilestoneIndex);
-          // We reissue the previous milestone again
-          broadcastLatestMilestone();
-          milestonePropagationRetries++;
-          // We wait a third of the milestone tick
-          Thread.sleep(milestoneTick / 3);
-          continue;
+          else {
+            throw new RuntimeException("Latest milestone " + state.latestMilestoneHash + " #" +
+                    state.latestMilestoneIndex + " is failing to propagate!!!");
+          }
         }
         milestonePropagationRetries = 0;
         // GetTransactionsToApprove will return tips referencing latest milestone.
@@ -281,53 +273,17 @@ public class Coordinator {
         trunk = txToApprove.getTrunkTransaction();
         branch = txToApprove.getBranchTransaction();
 
-        if (validatorAPIs.size() > 0) {
-          boolean isConsistent = validatorAPIs.parallelStream().allMatch(api -> {
-            CheckConsistencyResponse response;
-            try {
-              response = api.checkConsistency(trunk, branch);
-              if (!response.getState()) {
-                log.error("{} reported invalid consistency: {}", api.getHost(), response.getInfo());
-              }
-              return response.getState();
-            } catch (ArgumentException e) {
-              e.printStackTrace();
-              return false;
-            }
-          });
-
-          if (!isConsistent) {
-            String msg = "Trunk & branch were not consistent!!! T: " + trunk + " B: " + branch;
-
-            log.error(msg);
-            throw new RuntimeException(msg);
-          }
-
+        if (!validateTransactionsToApprove(trunk, branch)) {
+          throw new RuntimeException("Trunk & branch were not consistent!!! T: " + trunk + " B: " + branch);
         }
+
       }
 
       // If all the above checks pass we are ready to issue a new milestone
       state.latestMilestoneIndex++;
 
-      log.info("Issuing milestone: " + state.latestMilestoneIndex);
-      log.info("Trunk: " + trunk + " Branch: " + branch);
-
-      List<Transaction> latestMilestoneTransactions = db.createMilestone(trunk, branch, state.latestMilestoneIndex, config.MWM);
-      state.latestMilestoneTransactions = latestMilestoneTransactions.stream().map(Transaction::toTrytes).collect(Collectors.toList());
-      state.latestMilestoneHash = latestMilestoneTransactions.get(0).getHash();
-
-      // Do not store the state before broadcasting, since if broadcasting fails we should repeat the same milestone.
-      broadcastLatestMilestone();
-
-      if (bootstrap >= 3) {
-        nextDepth = getNextDepth(depth, state.latestMilestoneTime);
-      } else {
-        nextDepth = depth;
-      }
-
-      log.info("Depth: " + depth + " -> " + nextDepth);
-
-      depth = nextDepth;
+      createAndBroadcastMilestone(trunk, branch);
+      updateDepth(bootstrap);
       state.latestMilestoneTime = System.currentTimeMillis();
 
       // Everything went fine, now we store
@@ -342,5 +298,80 @@ public class Coordinator {
 
       Thread.sleep(milestoneTick);
     }
+  }
+
+  private void updateDepth(int bootstrap) {
+    int nextDepth;
+    if (bootstrap >= 3) {
+      nextDepth = getNextDepth(depth, state.latestMilestoneTime);
+    } else {
+      nextDepth = depth;
+    }
+
+    log.info("Depth: " + depth + " -> " + nextDepth);
+
+    depth = nextDepth;
+  }
+
+  private void createAndBroadcastMilestone(String trunk, String branch) throws ArgumentException {
+    log.info("Issuing milestone: " + state.latestMilestoneIndex);
+    log.info("Trunk: " + trunk + " Branch: " + branch);
+
+    List<Transaction> latestMilestoneTransactions = db.createMilestone(trunk, branch, state.latestMilestoneIndex, config.MWM);
+    state.latestMilestoneTransactions = latestMilestoneTransactions.stream().map(Transaction::toTrytes).collect(Collectors.toList());
+    state.latestMilestoneHash = latestMilestoneTransactions.get(0).getHash();
+
+    // Do not store the state before broadcasting, since if broadcasting fails we should repeat the same milestone.
+    broadcastLatestMilestone();
+  }
+
+  /**
+   * Checks the consistency of 2 given transactions against the nodes specified by {@link #validatorAPIs}
+   * @param trunk transaction to be approved by milestone
+   * @param branch transaction to be approved by milestone
+   * @return {@code true} if the checks passed or didn't take place. Else return {@code false}.
+   */
+  private boolean validateTransactionsToApprove(String trunk, String branch) {
+    if (validatorAPIs.size() > 0) {
+      boolean isConsistent = validatorAPIs.parallelStream().allMatch(api -> {
+        CheckConsistencyResponse response;
+        try {
+          response = api.checkConsistency(trunk, branch);
+          if (!response.getState()) {
+            log.error("{} reported invalid consistency: {}", api.getHost(), response.getInfo());
+          }
+          return response.getState();
+        } catch (ArgumentException e) {
+          e.printStackTrace();
+          return false;
+        }
+      });
+
+      return isConsistent;
+    }
+
+    //nothing was checked so validation can't fail
+    return true;
+  }
+
+  /**
+   * Attempts to rebroadcast the latest milestone. Should succeed if {@code milestonePropagationRetries}
+   * is not above configured threshold.
+   *
+   * @param milestonePropagationRetries number of propagation retries that have already taken place
+   * @param lsm latest solid milestone index
+   * @return {@code true} if the milestone was broadcasted again else return false
+   * @throws ArgumentException upon an API problem
+   */
+  private boolean attemptToRepropagateLatestMilestone(int milestonePropagationRetries, int lsm) throws ArgumentException {
+    // Bail if we attempted to broadcast the latest Milestone too many times
+    if (milestonePropagationRetries > config.propagationRetriesThreshold) {
+      return false;
+    }
+    log.warn("getNodeInfo returned latestSolidSubtangleMilestoneIndex #{}, " +
+            "it should be #{}. Rebroadcasting latest milestone.", lsm, state.latestMilestoneIndex);
+    // We reissue the previous milestone again
+    broadcastLatestMilestone();
+    return true;
   }
 }

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -54,6 +54,8 @@ public class Coordinator {
   private final CoordinatorConfiguration config;
   private CoordinatorState state;
   private List<IotaAPI> validatorAPIs;
+  private Thread workerThread;
+  private boolean shutdown;
 
   private long milestoneTick;
   private int depth;
@@ -61,6 +63,7 @@ public class Coordinator {
   private Coordinator(CoordinatorConfiguration config, CoordinatorState state, SignatureSource signatureSource) throws IOException {
     this.config = config;
     this.state = state;
+    this.shutdown = false;
     URL node = new URL(config.host);
 
     this.db = new MilestoneDatabase(config.powMode,
@@ -94,6 +97,19 @@ public class Coordinator {
       oos.writeObject(state);
       log.info("stored index {}", state.latestMilestoneIndex);
     }
+  }
+
+  private void shutdownHook() {
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      log.info("Shutting down Compass after next milestone...");
+      this.shutdown = true;
+      try {
+        this.workerThread.join();
+      } catch (InterruptedException e) {
+        String msg = "Interrupted while waiting for Compass to issue next milestone.";
+        log.error(msg, e);
+      }
+    }, "Shutdown Hook"));
   }
 
   public static void main(String[] args) throws Exception {
@@ -227,6 +243,8 @@ public class Coordinator {
   private void start() throws InterruptedException {
     int bootstrapStage = 0;
     int milestonePropagationRetries = 0;
+    this.workerThread = Thread.currentThread();
+    shutdownHook();
 
     while (true) {
       //assume that we will be calling gtta
@@ -262,6 +280,11 @@ public class Coordinator {
         }
         //normal flow
         else {
+          // We want to perform shutdown only when we are ready to issue the next normal milestone
+            // and the node is in sync with the latest milestone we issued.
+          if (shutdown) {
+            return;
+          }
           // GetTransactionsToApprove will return tips referencing latest milestone.
           GetTransactionsToApproveResponse txToApprove = null;
           try {

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -161,17 +161,21 @@ public class Coordinator {
    * @return true if node is solid
    */
   private boolean nodeIsSolid(GetNodeInfoResponse nodeInfo) {
-    if (nodeInfo.getLatestSolidSubtangleMilestoneIndex() != nodeInfo.getLatestMilestoneIndex())
-      return false;
-
-    if (!config.inception && (nodeInfo.getLatestSolidSubtangleMilestoneIndex() != state.latestMilestoneIndex))
-      return false;
-
     if (nodeInfo.getLatestMilestone().equals(MilestoneSource.EMPTY_HASH) ||
             nodeInfo.getLatestSolidSubtangleMilestone().equals(MilestoneSource.EMPTY_HASH))
       return false;
 
-    return true;
+    return nodeInfo.getLatestSolidSubtangleMilestoneIndex() == nodeInfo.getLatestMilestoneIndex();
+  }
+
+  /**
+   * Checks that node's latest solid milestone matches internal state.
+   *
+   * @param nodeInfo response from node API call
+   * @return true if node is solid
+   */
+  private boolean nodeMatchesInternalState(GetNodeInfoResponse nodeInfo) {
+    return config.inception || (nodeInfo.getLatestSolidSubtangleMilestoneIndex() == state.latestMilestoneIndex);
   }
 
   private void broadcastLatestMilestone() throws ArgumentException {
@@ -227,34 +231,20 @@ public class Coordinator {
   }
 
   private void start() throws ArgumentException, InterruptedException {
-    int bootstrap = config.bootstrap ? 0 : 3;
+    int bootstrapStage = 0;
     int milestonePropagationRetries = 0;
-    log.info("Bootstrap mode: " + bootstrap);
 
     while (true) {
       String trunk, branch;
       GetNodeInfoResponse nodeInfoResponse = api.getNodeInfo();
 
-      if (bootstrap == 2 && !nodeIsSolid(nodeInfoResponse)) {
-        log.warn("Node not solid.");
-        Thread.sleep(config.unsolidDelay);
-        continue;
-      }
-
-      // Node is solid.
-      if (bootstrap == 0) {
-        log.info("Bootstrapping network.");
-        trunk = MilestoneSource.EMPTY_HASH;
-        branch = MilestoneSource.EMPTY_HASH;
-        bootstrap = 1;
-      } else if (bootstrap < 3) {
-        // Bootstrapping means creating a chain of milestones without pulling in external transactions.
-        log.info("Reusing last milestone.");
-        trunk = state.latestMilestoneHash;
-        branch = MilestoneSource.EMPTY_HASH;
-        bootstrap++;
-      } else {
+      if (!config.bootstrap) {
         if (!nodeIsSolid(nodeInfoResponse)) {
+          log.warn("Node not solid.");
+          Thread.sleep(config.unsolidDelay);
+          continue;
+        }
+        if (!nodeMatchesInternalState(nodeInfoResponse)) {
           if (attemptToRepropagateLatestMilestone(milestonePropagationRetries,
                   nodeInfoResponse.getLatestSolidSubtangleMilestoneIndex())) {
             milestonePropagationRetries++;
@@ -268,6 +258,7 @@ public class Coordinator {
           }
         }
         milestonePropagationRetries = 0;
+
         // GetTransactionsToApprove will return tips referencing latest milestone.
         GetTransactionsToApproveResponse txToApprove = api.getTransactionsToApprove(depth, state.latestMilestoneHash);
         trunk = txToApprove.getTrunkTransaction();
@@ -277,13 +268,42 @@ public class Coordinator {
           throw new RuntimeException("Trunk & branch were not consistent!!! T: " + trunk + " B: " + branch);
         }
 
+      } else {
+        if (bootstrapStage >= 3) {
+          config.bootstrap = false;
+          continue;
+        }
+        if (bootstrapStage == 0) {
+          log.info("Bootstrapping network.");
+          trunk = MilestoneSource.EMPTY_HASH;
+          branch = MilestoneSource.EMPTY_HASH;
+          bootstrapStage = 1;
+        } else {
+          // Bootstrapping means creating a chain of milestones without pulling in external transactions.
+          log.info("Reusing last milestone.");
+          trunk = state.latestMilestoneHash;
+          branch = MilestoneSource.EMPTY_HASH;
+          bootstrapStage++;
+        }
+
+        if (bootstrapStage == 2) {
+          if (!nodeIsSolid(nodeInfoResponse)) {
+            log.warn("Node not solid.");
+            Thread.sleep(config.unsolidDelay);
+            continue;
+          } else if (!nodeMatchesInternalState(nodeInfoResponse)) {
+            log.warn("Node's solid milestone does not match Compass state: " + state.latestMilestoneIndex);
+            Thread.sleep(config.unsolidDelay);
+            continue;
+          }
+        }
       }
 
       // If all the above checks pass we are ready to issue a new milestone
       state.latestMilestoneIndex++;
 
       createAndBroadcastMilestone(trunk, branch);
-      updateDepth(bootstrap);
+      updateDepth(bootstrapStage);
       state.latestMilestoneTime = System.currentTimeMillis();
 
       // Everything went fine, now we store

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -107,6 +107,7 @@ public class Coordinator {
       // and to allow overriding state file using `-index` flag
     if (config.bootstrap || config.index != null) {
       state = new CoordinatorState();
+      state.latestMilestoneIndex = config.index == null ? 0 : config.index;
     } else {
       try {
         state = loadState(config.statePath);
@@ -195,11 +196,6 @@ public class Coordinator {
               !nodeInfoResponse.getLatestMilestone().equals(MilestoneSource.EMPTY_HASH)) {
         throw new RuntimeException("Network already bootstrapped");
       }
-    }
-
-    if (config.index != null) {
-      state = new CoordinatorState();
-      state.latestMilestoneIndex = config.index;
     }
 
     log.info("Starting index from: " + state.latestMilestoneIndex);

--- a/compass/Coordinator.java
+++ b/compass/Coordinator.java
@@ -191,7 +191,8 @@ public class Coordinator {
 
     if (config.bootstrap) {
       log.info("Bootstrapping.");
-      if (!nodeInfoResponse.getLatestSolidSubtangleMilestone().equals(MilestoneSource.EMPTY_HASH) || !nodeInfoResponse.getLatestMilestone().equals(MilestoneSource.EMPTY_HASH)) {
+      if (!nodeInfoResponse.getLatestSolidSubtangleMilestone().equals(MilestoneSource.EMPTY_HASH) ||
+              !nodeInfoResponse.getLatestMilestone().equals(MilestoneSource.EMPTY_HASH)) {
         throw new RuntimeException("Network already bootstrapped");
       }
     }
@@ -203,7 +204,8 @@ public class Coordinator {
 
     log.info("Starting index from: " + state.latestMilestoneIndex);
     if (nodeInfoResponse.getLatestMilestoneIndex() > state.latestMilestoneIndex && !config.inception) {
-      throw new RuntimeException("Provided index is lower than latest seen milestone: " + nodeInfoResponse.getLatestMilestoneIndex() + " vs " + state.latestMilestoneIndex);
+      throw new RuntimeException("Provided index is lower than latest seen milestone: " +
+              nodeInfoResponse.getLatestMilestoneIndex() + " vs " + state.latestMilestoneIndex);
     }
 
     milestoneTick = config.tick;
@@ -260,12 +262,16 @@ public class Coordinator {
         if (!nodeIsSolid(nodeInfoResponse)) {
           // Bail if we attempted to broadcast the latest Milestone too many times
           if (milestonePropagationRetries > config.propagationRetriesThreshold) {
-            String msg = "Latest milestone " + state.latestMilestoneHash + " #" + state.latestMilestoneIndex + " is failing to propagate!!!";
+            String msg =
+                    "Latest milestone " + state.latestMilestoneHash + " #" +
+                    state.latestMilestoneIndex + " is failing to propagate!!!";
 
             log.error(msg);
             throw new RuntimeException(msg);
           }
-          log.warn("getNodeInfo returned latestMilestoneIndex #{}, it should be #{}. Rebroadcasting latest milestone.", nodeInfoResponse.getLatestMilestoneIndex(), state.latestMilestoneIndex);
+          log.warn("getNodeInfo returned latestSolidSubtangleMilestoneIndex #{}, " +
+                  "it should be #{}. Rebroadcasting latest milestone.",
+                  nodeInfoResponse.getLatestSolidSubtangleMilestoneIndex(), state.latestMilestoneIndex);
           // We reissue the previous milestone again
           broadcastLatestMilestone();
           milestonePropagationRetries++;
@@ -275,7 +281,7 @@ public class Coordinator {
         }
         milestonePropagationRetries = 0;
         // GetTransactionsToApprove will return tips referencing latest milestone.
-        GetTransactionsToApproveResponse txToApprove = api.getTransactionsToApprove(depth, nodeInfoResponse.getLatestMilestone());
+        GetTransactionsToApproveResponse txToApprove = api.getTransactionsToApprove(depth, state.latestMilestoneHash);
         trunk = txToApprove.getTrunkTransaction();
         branch = txToApprove.getBranchTransaction();
 

--- a/compass/LayersCalculator.java
+++ b/compass/LayersCalculator.java
@@ -77,8 +77,11 @@ public class LayersCalculator implements Runnable {
   public void run() {
     Path layersPath = Paths.get(config.layersPath);
     try {
-      Files.createDirectory(layersPath);
+      if (Files.notExists(layersPath)) {
+        Files.createDirectory(layersPath);
+      }
     } catch (IOException e) {
+      log.warn("failed to create folder: " + layersPath, e);
     }
 
     List<String> addresses = calculateAllAddresses();
@@ -95,17 +98,17 @@ public class LayersCalculator implements Runnable {
     log.info("Successfully wrote Merkle Tree with root: " + layers.get(0).get(0));
   }
 
-  public List<String> calculateAllAddresses() {
+  //Package Private For Testing
+  List<String> calculateAllAddresses() {
     log.info("Calculating " + count + " addresses.");
-    List<String> outList = IntStream.range(0, count)
+    return IntStream.range(0, count)
         .mapToObj(signatureSource::getAddress)
         .parallel()
         .collect(Collectors.toList());
-
-    return outList;
   }
 
-  public List<List<String>> calculateAllLayers(List<String> addresses) {
+  //Package Private For Testing
+  List<List<String>> calculateAllLayers(List<String> addresses) {
     int depth = IntMath.log2(addresses.size(), RoundingMode.FLOOR);
     List<List<String>> layers = new ArrayList<>(depth);
     List<String> last = addresses;

--- a/compass/conf/CoordinatorConfiguration.java
+++ b/compass/conf/CoordinatorConfiguration.java
@@ -70,4 +70,9 @@ public class CoordinatorConfiguration extends BaseConfiguration {
   @Parameter(names = "-statePath", description = "Path to compass state file.")
   public String statePath = "compass.state";
 
+  @Parameter(names = "-APIRetries", description = "Number of attempts to retry failing API call.")
+  public int APIRetries = 5;
+
+  @Parameter(names = "-APIRetryInterval", description = "Interval (in milliseconds) to wait between failing API attempts.")
+  public int APIRetryInterval = 1000;
 }

--- a/compass/conf/CoordinatorConfiguration.java
+++ b/compass/conf/CoordinatorConfiguration.java
@@ -75,4 +75,7 @@ public class CoordinatorConfiguration extends BaseConfiguration {
 
   @Parameter(names = "-APIRetryInterval", description = "Interval (in milliseconds) to wait between failing API attempts.")
   public int APIRetryInterval = 1000;
+
+  @Parameter(names = "-referenceLastMilestone", description = "Generate a milestone that references the last and then exit")
+  public boolean referenceLastMilestone = false;
 }

--- a/compass/exceptions/BUILD
+++ b/compass/exceptions/BUILD
@@ -1,0 +1,9 @@
+MAIN_BASE_PATH = "src/main/java/org/iota/compass/%s"
+
+java_library(
+    name = "exceptions",
+    srcs = glob([
+        "*.java",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/compass/exceptions/TimeoutException.java
+++ b/compass/exceptions/TimeoutException.java
@@ -1,0 +1,26 @@
+package org.iota.compass.exceptions;
+
+/**
+ * Thrown if an API call to IRI is timed out
+ */
+public class TimeoutException extends Exception {
+
+    public TimeoutException() {
+    }
+
+    public TimeoutException(String message) {
+        super(message);
+    }
+
+    public TimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    public TimeoutException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/compass/milestone/MilestoneDatabase.java
+++ b/compass/milestone/MilestoneDatabase.java
@@ -207,6 +207,7 @@ public class MilestoneDatabase extends MilestoneSource {
     String bundleHash = calculateBundleHash(txs);
     txs.forEach(tx -> tx.setBundle(bundleHash));
 
+    txSiblings.setAttachmentTimestamp(System.currentTimeMillis());
     txSiblings.setNonce(pow.performPoW(txSiblings.toTrytes(), mwm).substring(NONCE_OFFSET));
     if (signatureSource.getSignatureMode() == SpongeFactory.Mode.KERL) {
       /*

--- a/compass/sign/RemoteSignatureSource.java
+++ b/compass/sign/RemoteSignatureSource.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLException;
 import java.io.File;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * An implementation of a SignatureSource that talks to a remote gRPC service.
@@ -42,6 +43,7 @@ public class RemoteSignatureSource extends SignatureSource {
     this(NettyChannelBuilder
         .forTarget(uri)
         .useTransportSecurity()
+        .idleTimeout(5, TimeUnit.SECONDS)
         .sslContext(
             buildSslContext(trustCertCollectionFilePath, clientCertChainFilePath, clientPrivateKeyFilePath))
         .build());
@@ -54,7 +56,7 @@ public class RemoteSignatureSource extends SignatureSource {
    * @param uri the URI of the host to connect to
    */
   public RemoteSignatureSource(String uri) {
-    this(ManagedChannelBuilder.forTarget(uri).usePlaintext().build());
+    this(ManagedChannelBuilder.forTarget(uri).usePlaintext().idleTimeout(5, TimeUnit.SECONDS).build());
   }
 
   private RemoteSignatureSource(ManagedChannel channel) {

--- a/compass/sign/RemoteSignatureSource.java
+++ b/compass/sign/RemoteSignatureSource.java
@@ -103,7 +103,10 @@ public class RemoteSignatureSource extends SignatureSource {
     try {
       response = serviceStub.getSignature(GetSignatureRequest.newBuilder().setIndex(index).setHash(hash).build());
     } catch (StatusRuntimeException e) {
-      // If an exception occurs we retry only once by rebuilding the gRPC client stub from a new Channel
+      // If an exception occurs, wait 10 seconds, and retry only once by rebuilding the gRPC client stub from a new Channel
+      try {
+        Thread.sleep(10000);
+      } catch (InterruptedException ex) {}
       serviceStub = SignatureSourceGrpc.newBlockingStub(channelBuilder.build());
       response = serviceStub.getSignature(GetSignatureRequest.newBuilder().setIndex(index).setHash(hash).build());
     }

--- a/compass/simplelogger.properties
+++ b/compass/simplelogger.properties
@@ -27,7 +27,7 @@ org.slf4j.simpleLogger.defaultLogLevel=info
 #org.slf4j.simpleLogger.log.xxxxx=
 
 org.slf4j.simpleLogger.showDateTime=true
-#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
 
 org.slf4j.simpleLogger.showThreadName=true
 org.slf4j.simpleLogger.showLogName=true

--- a/docs/private_tangle/02_run_iri.sh
+++ b/docs/private_tangle/02_run_iri.sh
@@ -12,6 +12,8 @@ docker run -t --net host --rm -v $scriptdir/db:/iri/data -v $scriptdir/snapshot.
        --testnet \
        --remote \
        --testnet-coordinator $COO_ADDRESS \
+       --testnet-coordinator-security-level $security \
+       --testnet-coordinator-signature-mode $sigMode \
        --mwm $mwm \
        --milestone-start $milestoneStart \
        --milestone-keys $depth \

--- a/docs/private_tangle/03_run_coordinator.sh
+++ b/docs/private_tangle/03_run_coordinator.sh
@@ -7,6 +7,7 @@ load_config
 
 docker run -t --net host --rm -v $scriptdir/data:/data iota/compass/docker:coordinator coordinator_deploy.jar \
 	-layers /data/layers \
+	-statePath /data/compass.state \
 	-sigMode $sigMode \
 	-powMode $powMode \
 	-mwm $mwm \

--- a/docs/private_tangle/11_run_signature_source_server.sh
+++ b/docs/private_tangle/11_run_signature_source_server.sh
@@ -5,7 +5,7 @@ scriptdir=$(dirname "$(readlink -f "$0")")
 
 load_config
 
-docker run -t --net host --rm -v $scriptdir/data:/data iota/compass/docker:signature_source_server signature_source_server_deploy.jar \
+docker run -t --net host --rm -v $scriptdir/data:/data iota/compass/docker:signature_source_server server_deploy.jar \
 	-sigMode $sigMode \
 	-security $security \
 	-seed $seed \

--- a/docs/private_tangle/12_run_coordinator_remote.sh
+++ b/docs/private_tangle/12_run_coordinator_remote.sh
@@ -7,6 +7,7 @@ load_config
 
 docker run -t --net host --rm -v $scriptdir/data:/data iota/compass/docker:coordinator coordinator_deploy.jar \
 	-layers /data/layers \
+	-statePath /data/compass.state \
 	-powMode $powMode \
 	-mwm $mwm \
 	-tick $tick \

--- a/third-party/maven_deps.bzl
+++ b/third-party/maven_deps.bzl
@@ -132,7 +132,7 @@ def maven_jars():
         name = "com_google_j2objc_j2objc_annotations",
         artifact = "com.google.j2objc:j2objc-annotations:1.1",
         repository = "https://jcenter.bintray.com/",
-        sha1 = "976d8d30bebc251db406f2bdb3eb01962b5685b3",
+        sha1 = "ed28ded51a8b1c6b112568def5f4b455e6809019",
     )
 
     # org.iota:jota:1.0.0-beta3


### PR DESCRIPTION
Use the same ManagedChannelBuilder, but recreate the gRPC client Stub upon network exception from a brand new ChannelBuilder.
Additionally JVM internal DNS cache has been limited 5 seconds, for positive and negative lookups (https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html). 